### PR TITLE
Fix project URL in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     author='Andrew Svetlov',
     author_email='andrew.svetlov@gmail.com',
-    url='https://github.com/aio-libs/multidict/',
+    url='https://github.com/aio-libs/pytest-aiohttp/',
     license='Apache 2',
     install_requires=[
         'pytest',
@@ -46,3 +46,4 @@ setup(
         'pytest11': ['aiohttp = pytest_aiohttp'],
     },
 )
+


### PR DESCRIPTION
The **Home Page** URL at the PyPI points to wrong repository.

![image](https://cloud.githubusercontent.com/assets/957767/17055245/3c042378-5014-11e6-81c2-efea0b5e5670.png)

Replaced with correct one.