### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Testing',
         'Framework :: Pytest',
+        'Framework :: AsyncIO',
     ],
     author='Andrew Svetlov',
     author_email='andrew.svetlov@gmail.com',


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.