### PR TITLE
Fix test running with pytest-asyncio==0.18.0

### DIFF
--- a/pytest_aiohttp/plugin.py
+++ b/pytest_aiohttp/plugin.py
@@ -135,7 +135,7 @@ def aiohttp_client_cls() -> Type[TestClient]:
     return TestClient
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def aiohttp_client(
     aiohttp_client_cls: Type[TestClient],
 ) -> Generator[AiohttpClient, None, None]:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Fix for https://github.com/aio-libs/pytest-aiohttp/issues/25
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No. `asyncio_mode=strict` will start working again.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
25
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
