### PR TITLE
Fix example in README not working

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ The simple usage example:
 
 
     async def test_hello(aiohttp_client):
-        client = await aiohttp_client(await create_app())
+        client = await aiohttp_client(create_app())
         resp = await client.get("/")
         assert resp.status == 200
         text = await resp.text()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The existing example in README.rst does not work. This change removes the unnecessary `await` keyword so that the example becomes functional.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
