### PR TITLE
Update check-jsonschema URL and version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,8 @@ repos:
   rev: v1.9.0
   hooks:
   - id: python-use-type-annotations
-- repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.18.4
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.19.2
   hooks:
   - id: check-github-actions
   - id: check-github-workflows


### PR DESCRIPTION
👋 Hi, `check-jsonschema` maintainer here!

I'm doing some searches to try to find high-profile repos still using the old repo URL, so that we can get it updated across as many projects as possible.

I notice that the hooks are disabled in pre-commit.ci .
I'm not sure if there's a deeper reason for that, but since v0.8.x , it should be possible to run in that context (whereas prior to those versions running in pre-commit.ci would fail).
Since I'm not clear on the reason, I haven't suggested an update, but I wanted to point you in this direction.