### PR TITLE
Update `pytest-asyncio` version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ setup_requires =
 install_requires =
   pytest >= 6.1.0
   aiohttp >= 3.8.1
-  pytest-asyncio >= 0.17.2
+  pytest-asyncio >= 0.23.4
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Raise up `pytest-asyncio` version. Otherwise dependabot tries to upgrade pytest to 8.0.0 that is incompatible with `pytest-asyncio < 0.23.4`

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
