### PR TITLE
Export types at top-level

### DIFF
--- a/pytest_aiohttp/__init__.py
+++ b/pytest_aiohttp/__init__.py
@@ -1,1 +1,6 @@
 from ._version import version as __version__  # noqa
+from .plugin import (
+    AiohttpClient as AiohttpClient,
+    AiohttpRawServer as AiohttpRawServer,
+    AiohttpServer as AiohttpServer,
+)

--- a/pytest_aiohttp/__init__.py
+++ b/pytest_aiohttp/__init__.py
@@ -1,6 +1,6 @@
 from ._version import version as __version__  # noqa: F401
 from .plugin import (
-    AiohttpClient as AiohttpClient,  # noqa: F401
-    AiohttpRawServer as AiohttpRawServer,  # noqa: F401
-    AiohttpServer as AiohttpServer,  # noqa: F401
+    AiohttpClient as AiohttpClient,
+    AiohttpRawServer as AiohttpRawServer,
+    AiohttpServer as AiohttpServer,
 )

--- a/pytest_aiohttp/__init__.py
+++ b/pytest_aiohttp/__init__.py
@@ -1,5 +1,5 @@
 from ._version import version as __version__  # noqa: F401
-from .plugin import (
+from .plugin import (  # noqa: F401
     AiohttpClient as AiohttpClient,
     AiohttpRawServer as AiohttpRawServer,
     AiohttpServer as AiohttpServer,

--- a/pytest_aiohttp/__init__.py
+++ b/pytest_aiohttp/__init__.py
@@ -1,6 +1,6 @@
-from ._version import version as __version__  # noqa
+from ._version import version as __version__  # noqa: F401
 from .plugin import (
-    AiohttpClient as AiohttpClient,
-    AiohttpRawServer as AiohttpRawServer,
-    AiohttpServer as AiohttpServer,
+    AiohttpClient as AiohttpClient,  # noqa: F401
+    AiohttpRawServer as AiohttpRawServer,  # noqa: F401
+    AiohttpServer as AiohttpServer,  # noqa: F401
 )


### PR DESCRIPTION
So they can be imported easily for type annotations.