### PR TITLE
tests: add pytest.ini to set asyncio_default_fixture_loop_scope

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
## What do these changes do?
Adds pytest.ini to set 'asyncio_default_fixture_loop_scope = function' 
to prevent pytest-asyncio deprecation warnings breaking pytester tests.

## Are there changes in behavior for the user?
None; only affects test runs.

## Checklist
- [x] I think the code is well written
- [x] Unit tests for the changes exist (pytest.ini affects tests)
